### PR TITLE
修复榜单为空的越界问题

### DIFF
--- a/module/board/misc.py
+++ b/module/board/misc.py
@@ -79,10 +79,10 @@ def generate_board_data(submissions: list[SubmissionData], verdict: str) -> Misc
 
 def _slice_rank_data(rank: list[dict], lim: int, show_unrated: bool = True) -> list[dict]:
     """针对有排名并列时的切片"""
-    if len(rank) == 0:
+    unrated_excluded = [rank_data for rank_data in rank if not rank_data.get('unrated')]
+    if len(unrated_excluded) == 0:
         return []
 
-    unrated_excluded = [rank_data for rank_data in rank if not rank_data.get('unrated')]
     max_rank = min(lim, unrated_excluded[len(unrated_excluded) - 1]['rank'])
     if not show_unrated:  # 预处理，避免后续无效绘图对象的预绘制
         max_rank = lim


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了排行榜切片在空数据或全部未评级情况下可能触发的运行时错误。
  * 现在在相关数据为空时会安全返回空结果，避免异常中断。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->